### PR TITLE
Update EU Localizable.strings

### DIFF
--- a/Localization/eu.lproj/Localizable.strings
+++ b/Localization/eu.lproj/Localizable.strings
@@ -116,7 +116,7 @@
 "userProfile.title.report" = "Salatu";
 "userProfile.title.followsYou" = "Jarraitzen dizu";
 "userProfile.title.requestFollow" = "Egin jarraitzeko eskaera";
-"userProfile.title.cancelRequestFollow" = "Bertan behera utzi jarraitzeko eskaera";
+"userProfile.title.cancelRequestFollow" = "Utzi bertan behera jarraitzeko eskaera";
 "userProfile.title.followRequests" = "Jarraipen-eskaerak";
 "userProfile.title.privateProfileTitle" = "Profil hau pribatua da.";
 "userProfile.title.privateProfileSubtitle" = "Baimendutako jarraitzaileek soilik ikus ditzakete argazkiak.";
@@ -128,9 +128,9 @@
 "userProfile.title.edit" = "Editatu";
 "userProfile.title.muted" = "Mutututa";
 "userProfile.title.blocked" = "Blokeatuta";
-"userProfile.title.enableBoosts" = "Enable boosts";
-"userProfile.title.disableBoosts" = "Disable boosts";
-"userProfile.title.boostedStatusesMuted" = "Boosts muted";
+"userProfile.title.enableBoosts" = "Ikusi bultzadak";
+"userProfile.title.disableBoosts" = "Ezkutatu bultzadak";
+"userProfile.title.boostedStatusesMuted" = "Bultzadak mututu dira";
 
 // Mark: Notifications view.
 "notifications.navigationBar.title" = "Jakinarazpenak";
@@ -175,7 +175,7 @@
 "photoEdit.navigationBar.title" = "Argazkiaren xehetasunak";
 "photoEdit.title.photo" = "Argazkia";
 "photoEdit.title.accessibility" = "Irisgarritasuna";
-"photoEdit.title.accessibilityDescription" = "Ikusmen arazoak dituztenentzat deskribapena";
+"photoEdit.title.accessibilityDescription" = "Ikusmen urritasuna dutenentzat deskribapena";
 "photoEdit.title.save" = "Gorde";
 "photoEdit.title.cancel" = "Utzi";
 "photoEdit.error.updatePhotoFailed" = "Errorea argazkia eguneratzean.";
@@ -244,9 +244,9 @@
 "settings.title.warnAboutMissingAltTitle" = "Abisatu ALT ahaztu bazait";
 "settings.title.warnAboutMissingAltDescription" = "Irudiren batek deskribapenik ez badu, argitaratu baino lehen abisua erakutsiko da.";
 "settings.title.enableReboostOnTimeline" = "Erakutsi bultzatutako egoerak";
-"settings.title.enableReboostOnTimelineDescription" = "Besteek bultzatu dituzten egoerak zure denbora-lerroan erakutsiko dira.";
-"settings.title.hideStatusesWithoutAlt" = "Hide statuses without ALT text";
-"settings.title.hideStatusesWithoutAltDescription" = "Statuses without ALT text will not be visible on your home timeline.";
+"settings.title.enableReboostOnTimelineDescription" = "Besteek bultzatu dituzten egoerak denbora-lerroan erakutsiko dira.";
+"settings.title.hideStatusesWithoutAlt" = "Ezkutatu ALT gabeko egoerak";
+"settings.title.hideStatusesWithoutAltDescription" = "Deskribapen edo testu alternatiborik ez duten egoerak ez dira denbora-lerroan erakutsiko.";
 
 // Mark: Signin view.
 "signin.navigationBar.title" = "Hasi saioa Pixelfed-en";


### PR DESCRIPTION
- Translated: Boosts muted and hide status without ALT text, plus a few minor fixes and missing strings.

- I have translated *enable/disable boosts* as *show/hide boosts*, at least for now. I think that enable/disable boosts could fit better as a setting when composing a new status, the same way enable or disable replies/comments works.