### PR TITLE
Publish without text

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,9 +46,5 @@ From time to time you have to come back and translate lines which has been added
 Things that should be implemented in version 2.0:
 
  - [ ] Use auto generated resources (Color/Images) instead static extensions (how to do this in separete Swift Packages?)
- - [x] Move to xcstring (new Xcode transaction system)
- - [x] Move to new Observable macro (iOS 17)
- - [x] Migrate to SwiftData (iOS 17)
- - [ ] Use ViewModels
- - [x] Add tips (new TipKit framework in iOS 17)
+ - [ ] Use ViewModels?
  - [ ] Enable swiftlint (https://github.com/realm/SwiftLint/issues/5053)

--- a/Vernissage/Widgets/InteractionRow.swift
+++ b/Vernissage/Widgets/InteractionRow.swift
@@ -196,7 +196,7 @@ struct InteractionRow: View {
     }
 
     private func deleteStatus() {
-        Task {
+        Task { @MainActor in
             do {
                 // Remove from server.
                 try await self.client.statuses?.delete(statusId: self.statusModel.id)

--- a/WidgetsKit/Sources/WidgetsKit/Views/BaseComposeView.swift
+++ b/WidgetsKit/Sources/WidgetsKit/Views/BaseComposeView.swift
@@ -581,11 +581,6 @@ public struct BaseComposeView: View {
     }
 
     private func isPublishButtonDisabled() -> Bool {
-        // Publish always disabled when there is not status text.
-        if self.textModel.text.string.isEmpty {
-            return true
-        }
-
         // When application is during uploading photos we cannot send new status.
         if self.photosAreUploading == true {
             return true
@@ -593,6 +588,11 @@ public struct BaseComposeView: View {
 
         // When status is not a comment, then photo is required.
         if self.statusViewModel == nil && self.photosAttachment.hasUploadedPhotos() == false {
+            return true
+        }
+        
+        // When status is a comment, then text is required.
+        if self.statusViewModel != nil && self.textModel.text.string.isEmpty {
             return true
         }
 


### PR DESCRIPTION
Now we can publish statuses only with images attached (comments still require a text).