### PR TITLE
Rephrase odd German translations

### DIFF
--- a/Localization/Localizable.xcstrings
+++ b/Localization/Localizable.xcstrings
@@ -5943,7 +5943,7 @@
         "de" : {
           "stringUnit" : {
             "state" : "needs_review",
-            "value" : "Geboostete Status anzeigen"
+            "value" : "Boosts anzeigen"
           }
         },
         "en" : {
@@ -5984,7 +5984,7 @@
         "de" : {
           "stringUnit" : {
             "state" : "needs_review",
-            "value" : "Geboostete Status werden in Deiner Haupttimeline angezeigt."
+            "value" : "Geboostete Statusmeldung werden in Deiner Timeline angezeigt."
           }
         },
         "en" : {

--- a/Localization/Localizable.xcstrings
+++ b/Localization/Localizable.xcstrings
@@ -5943,7 +5943,7 @@
         "de" : {
           "stringUnit" : {
             "state" : "needs_review",
-            "value" : "Erhöhte Zustände anzeigen"
+            "value" : "Geboostete Status anzeigen"
           }
         },
         "en" : {
@@ -5984,7 +5984,7 @@
         "de" : {
           "stringUnit" : {
             "state" : "needs_review",
-            "value" : "Erhöhte Status werden auf Ihrer privaten Zeitleiste angezeigt."
+            "value" : "Geboostete Status werden in Deiner Haupttimeline angezeigt."
           }
         },
         "en" : {

--- a/Localization/Localizable.xcstrings
+++ b/Localization/Localizable.xcstrings
@@ -12467,7 +12467,7 @@
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Am %@ beigetreten"
+            "value" : "Beigetreten %@"
           }
         },
         "en" : {

--- a/Localization/Localizable.xcstrings
+++ b/Localization/Localizable.xcstrings
@@ -5984,7 +5984,7 @@
         "de" : {
           "stringUnit" : {
             "state" : "needs_review",
-            "value" : "Geboostete Statusmeldung werden in Deiner Timeline angezeigt."
+            "value" : "Geboostete Statusmeldungen werden in Deiner Timeline angezeigt."
           }
         },
         "en" : {

--- a/Localization/Localizable.xcstrings
+++ b/Localization/Localizable.xcstrings
@@ -6388,7 +6388,7 @@
         "de" : {
           "stringUnit" : {
             "state" : "needs_review",
-            "value" : "Statusmeldungen ohne ALT-Text werden nicht auf der eigenen Zeitleiste angezeigt."
+            "value" : "Statusmeldungen ohne ALT-Text werden nicht auf Deiner Timeline angezeigt."
           }
         },
         "en" : {
@@ -7037,7 +7037,7 @@
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "ALT-Icons werden in der Zeitleiste angezeigt"
+            "value" : "ALT-Icons werden in der Timeline angezeigt"
           }
         },
         "en" : {
@@ -7201,7 +7201,7 @@
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Favoriten werden in der Zeitleiste angezeigt"
+            "value" : "Favoriten werden in der Timeline angezeigt"
           }
         },
         "en" : {

--- a/Localization/Localizable.xcstrings
+++ b/Localization/Localizable.xcstrings
@@ -3317,7 +3317,7 @@
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Zuhause"
+            "value" : "Deine Timeline"
           }
         },
         "en" : {


### PR DESCRIPTION
In #99, we didn’t notice the context this would be used in, so we translated the `userProfile.title.joined` in a way that doesn’t work with the replacement that is done in code.

The current version leads to

> Am vor 3 Monaten beigetreten

which can be compared to

> On three months ago joined

The replacement would be like the English version and would be more grammatical.

![IMG_80ADABFCA1B6-1](https://github.com/VernissageApp/Vernissage/assets/9012887/e5669b4a-89fa-44ee-a3d5-2eb58b9f0363)

---

There’s also an odd translation that we did _not_ add in #99 so not sure where this came from:

![grafik](https://github.com/VernissageApp/Vernissage/assets/9012887/213effa5-2c81-40ce-bdcc-b6b44e8f1335)

I’ve replaced it in dde4520.