### PR TITLE
[#111] Display of wording value instead of wording key in tips

### DIFF
--- a/WidgetsKit/Sources/WidgetsKit/Tips/MainNavigationTip.swift
+++ b/WidgetsKit/Sources/WidgetsKit/Tips/MainNavigationTip.swift
@@ -14,11 +14,11 @@ public struct MainNavigationTip: Tip {
     }
     
     public var title: Text {
-        Text("tip.mainNavigation.title", bundle: Bundle.module, comment: "Main navigation tip title.")
+        Text(NSLocalizedString("tip.mainNavigation.title", bundle: Bundle.module, comment: "Main navigation tip title."))
     }
 
     public var message: Text? {
-        Text("tip.mainNavigation.message", bundle: Bundle.module, comment: "Main navigation tip message.")
+        Text(NSLocalizedString("tip.mainNavigation.message", bundle: Bundle.module, comment: "Main navigation tip message."))
     }
 
     public var image: Image? {

--- a/WidgetsKit/Sources/WidgetsKit/Tips/MenuCustomizableTip.swift
+++ b/WidgetsKit/Sources/WidgetsKit/Tips/MenuCustomizableTip.swift
@@ -14,11 +14,11 @@ public struct MenuCustomizableTip: Tip {
     }
 
     public var title: Text {
-        Text("tip.menuCustomizable.title", bundle: Bundle.module, comment: "Menu customizable tip title.")
+        Text(NSLocalizedString("tip.menuCustomizable.title", bundle: Bundle.module, comment: "Menu customizable tip title."))
     }
 
     public var message: Text? {
-        Text("tip.menuCustomizable.message", bundle: Bundle.module, comment: "Menu customizable tip message.")
+        Text(NSLocalizedString("tip.menuCustomizable.message", bundle: Bundle.module, comment: "Menu customizable tip message."))
     }
 
     public var image: Image? {

--- a/WidgetsKit/Sources/WidgetsKit/Tips/TimelineDoubleTapTip.swift
+++ b/WidgetsKit/Sources/WidgetsKit/Tips/TimelineDoubleTapTip.swift
@@ -14,11 +14,11 @@ public struct TimelineDoubleTapTip: Tip {
     }
     
     public var title: Text {
-        Text("tip.timelineDoubleTap.title", bundle: Bundle.module, comment: "Timeline double tip title.")
+        Text(NSLocalizedString("tip.timelineDoubleTap.title", bundle: Bundle.module, comment: "Timeline double tip title."))
     }
 
     public var message: Text? {
-        Text("tip.timelineDoubleTap.message", bundle: Bundle.module, comment: "Timeline double tip message.")
+        Text(NSLocalizedString("tip.timelineDoubleTap.message", bundle: Bundle.module, comment: "Timeline double tip message."))
     }
 
     public var image: Image? {


### PR DESCRIPTION
# Related issue

#111 

# Screen shots

## Before (with bug)

![wordking key displayed](https://github.com/VernissageApp/Vernissage/assets/7559007/11404499-468a-4915-b149-4d5c698bf093)

## After (with fix)

![wording value displayed](https://github.com/VernissageApp/Vernissage/assets/7559007/26647a43-2d81-417c-895b-b79c5b502c88)

